### PR TITLE
add gem version badge to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,7 +1,6 @@
 = Mods
 
-{<img src="https://secure.travis-ci.org/sul-dlss/mods.png?branch=master" alt="Build Status" />}[http://travis-ci.org/sul-dlss/mods]
-{<img src="https://gemnasium.com/sul-dlss/mods.png" alt="Dependency Status" />}[https://gemnasium.com/sul-dlss/mods]
+{<img src="https://secure.travis-ci.org/sul-dlss/mods.png?branch=master" alt="Build Status" />}[http://travis-ci.org/sul-dlss/mods] {<img src="https://gemnasium.com/sul-dlss/mods.png" alt="Dependency Status" />}[https://gemnasium.com/sul-dlss/mods] {<img src="https://badge.fury.io/rb/mods.svg" alt="Gem Version" />}[http://badge.fury.io/rb/mods]
 
 A Gem to parse MODS (Metadata Object Description Schema) records.  More information about MODS can be found at http://www.loc.gov/standards/mods/registry.php.
 


### PR DESCRIPTION
@bess - Is it possible you tagged a new version but didn't make a new gem release?  I'm going through my email of last week;  found a message about a travis build passing for ?? a tag  0.0.24 ??:

https://travis-ci.org/sul-dlss/mods/builds/30028693

Do we need to cut a new gem release?  I can show you how.

@lmcglohon  -- can you do a fast-forward merge for this (maybe show bess how to merge a pull request with a fast-forward merge) and then I can show you both how to release the gem?

It will need:  updated version number in the lib/version file;  I also try to put comments at the bottom of the readme ...

AND, see #6 -- we should add coveralls for code coverage to this too.

Isn't maintenance fun????
