### PR TITLE
Pinned nokogiri version to < 1.6.6 because of addition of Mode#lang in 1.6.6.1 which conflicts with currently used nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 script: rake rspec
 rvm:
   - 2.2.0
-  - 2.1.5
   - 2.1.1
   - 2.0.0
   - 1.9.3

--- a/README.rdoc
+++ b/README.rdoc
@@ -44,6 +44,7 @@ Create a new Mods::Record from a file:
 == Releases
 
 =======
+* <b>0.1.0</b> Pinned version of nokogiri to < 1.6.6 because of addition of Node#lang in 1.6.6.1 which conflicts which currently used nodes
 * <b>0.0.23</b> minor bug and typo fixes
 * <b>0.0.22</b> add displayLabel and lang attributes to every element
 * <b>0.0.21</b> bug fix to check for nil values in name nodes

--- a/mods.gemspec
+++ b/mods.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ["lib"]
   
-  gem.add_dependency 'nokogiri'
+  gem.add_dependency 'nokogiri', '< 1.6.6'  # v.1.6.6.1 added Node#lang which conflicts with currently used nodes
   gem.add_dependency 'nom-xml'
   gem.add_dependency 'iso-639'
 


### PR DESCRIPTION
@ndushay 