### PR TITLE
Drop support for old nokogiri

### DIFF
--- a/lib/mods/nom_terminology.rb
+++ b/lib/mods/nom_terminology.rb
@@ -3,10 +3,7 @@ module Mods
   # from:  http://www.loc.gov/standards/mods/v3/mods-userguide-generalapp.html
 
   # Nokogiri 1.6.6 introduced lang as a built-in attribute
-  LANG_ATTRIBS = (Nokogiri::VERSION < "1.6.6") ?
-      ['script', 'transliteration', 'lang'] :
-      ['script', 'transliteration']
-
+  LANG_ATTRIBS = ['script', 'transliteration']
   LINKING_ATTRIBS = ['xlink', 'ID']
 
   DATE_ATTRIBS = ['encoding', 'point', 'keyDate', 'qualifier']

--- a/mods.gemspec
+++ b/mods.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'nokogiri'
+  gem.add_dependency 'nokogiri', '>= 1.6.6'
   gem.add_dependency 'nom-xml', '~> 1.0'
   gem.add_dependency 'iso-639'
   gem.add_dependency 'edtf'


### PR DESCRIPTION
We had a version comparison of version strings, which no longer works now that
Nokogiri 1.10 is released.  Instead of fixing the comparison, just stop supporting
those old versions.

Fixes #33 