### PR TITLE
Use the EDTF::Interval definition of precision for arbitrary  intervals

### DIFF
--- a/lib/mods/date.rb
+++ b/lib/mods/date.rb
@@ -460,6 +460,8 @@ module Mods
         :century
       elsif date_range.is_a? EDTF::Decade
         :decade
+      elsif date.is_a? EDTF::Interval
+        date_range.precision
       else
         case date.precision
         when :month

--- a/spec/lib/date_spec.rb
+++ b/spec/lib/date_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe Mods::Date do
       '1900-06' => :month,
       '1900-06-uu' => :month,
       '1900-06-15' => :day,
+      '2014-01-01/2020-12-31' => :day
     }.each do |data, expected|
       describe "with #{data}" do
         let(:date_element) { "<dateCreated encoding=\"edtf\">#{data}</dateCreated>" }


### PR DESCRIPTION
Fixes https://app.honeybadger.io/projects/57331/faults/50864027

```
NoMethodError: undefined method `unspecified' for #<EDTF::Interval:0x0000000002bef1e8 @from=Wed, 01 Jan 2014, @to=Thu, 31 Dec 2020>
```