### PR TITLE
Use lowercase 'x' as EDTF masked precision marker

### DIFF
--- a/lib/mods/date.rb
+++ b/lib/mods/date.rb
@@ -183,7 +183,7 @@ module Mods
 
       def self.munge_to_yyyy(text)
         value = roman_to_int(text.upcase)
-        (value - 1).to_s.rjust(2, "0") + 'XX'
+        (value - 1).to_s.rjust(2, "0") + 'xx'
       end
     end
 
@@ -194,7 +194,7 @@ module Mods
       REGEX = /(?<century>\d{2})--/
       def self.normalize_to_edtf(text)
         matches = text.match(REGEX)
-        "#{matches[:century]}XX"
+        "#{matches[:century]}xx"
       end
     end
 
@@ -204,7 +204,7 @@ module Mods
 
       def self.normalize_to_edtf(text)
         matches = text.match(REGEX)
-        "#{matches[:century].to_i - 1}XX"
+        "#{matches[:century].to_i - 1}xx"
       end
     end
 
@@ -224,7 +224,7 @@ module Mods
 
       def self.normalize_to_edtf(text)
         matches = text.match(REGEX)
-        "#{matches[:year]}X"
+        "#{matches[:year]}x"
       end
     end
 
@@ -234,7 +234,7 @@ module Mods
 
       def self.normalize_to_edtf(text)
         matches = text.match(REGEX)
-        "#{matches[:year]}X"
+        "#{matches[:year]}x"
       end
     end
 
@@ -540,7 +540,7 @@ module Mods
 
     def date_range
       @date_range ||= if text =~ /u/
-        ::Date.edtf(text.gsub('u', 'X')) || date
+        ::Date.edtf(text.gsub('u', 'x').gsub('X', 'x')) || date
       else
         date
       end

--- a/spec/lib/date_spec.rb
+++ b/spec/lib/date_spec.rb
@@ -202,9 +202,9 @@ RSpec.describe Mods::Date do
     {
       '1905' => Date.parse('1905-01-01')..Date.parse('1905-12-31'),
       '190u' => Date.parse('1900-01-01')..Date.parse('1909-12-31'),
-      '190X' => Date.parse('1900-01-01')..Date.parse('1909-12-31'),
+      '190x' => Date.parse('1900-01-01')..Date.parse('1909-12-31'),
       '19uu' => Date.parse('1900-01-01')..Date.parse('1999-12-31'),
-      '19XX' => Date.parse('1900-01-01')..Date.parse('1999-12-31'),
+      '19xx' => Date.parse('1900-01-01')..Date.parse('1999-12-31'),
       '1856/1876' => Date.parse('1856-01-01')..Date.parse('1876-12-31'),
       '[1667,1668,1670..1672]' => Date.parse('1667-01-01')..Date.parse('1672-12-31'),
       '1900-uu' => Date.parse('1900-01-01')..Date.parse('1900-12-31'),


### PR DESCRIPTION
Fixes #54
