### PR TITLE
add nameIdentifier child to name for orcid ids

### DIFF
--- a/lib/mods/name.rb
+++ b/lib/mods/name.rb
@@ -2,8 +2,8 @@ module Mods
 
   class Name
 
-    CHILD_ELEMENTS = ['namePart', 'displayForm', 'affiliation', 'role', 'description']
-        
+    CHILD_ELEMENTS = ['namePart', 'displayForm', 'affiliation', 'role', 'nameIdentifier', 'description']
+
     # attributes on name node
     ATTRIBUTES = Mods::AUTHORITY_ATTRIBS + Mods::LANG_ATTRIBS + ['type', 'displayLabel', 'usage', 'altRepGroup', 'nameTitleGroup']
 
@@ -11,7 +11,7 @@ module Mods
     TYPES = ['personal', 'corporate', 'conference', 'family']
     # valid values for type attribute on namePart node <name><namePart type="val"/></name>
     NAME_PART_TYPES = ['date', 'family', 'given', 'termsOfAddress']
-  
+
   end
-  
+
 end

--- a/lib/mods/nom_terminology.rb
+++ b/lib/mods/nom_terminology.rb
@@ -143,6 +143,9 @@ module Mods
           end
           n.displayForm :path => 'm:displayForm'
           n.affiliation :path => 'm:affiliation'
+          n.nameIdentifier :path => 'm:nameIdentifier' do |ni|
+            with_attributes(ni, Mods::LANG_ATTRIBS | %w[displayLabel type typeURI invalid])
+          end
           n.description_el :path => 'm:description' # description is used by Nokogiri
           n.role :path => 'm:role' do |r|
             r.roleTerm :path => 'm:roleTerm' do |rt|

--- a/spec/lib/name_spec.rb
+++ b/spec/lib/name_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe "Mods <name> Element" do
         <name>
           <namePart>Exciting Prints</namePart>
           <affiliation>whatever</affiliation>
+          <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0002-0666-0666</nameIdentifier>
           <description>anything</description>
           <role><roleTerm type='text'>some role</roleTerm></role>
         </name>
@@ -280,6 +281,26 @@ RSpec.describe "Mods <name> Element" do
     end
   end
 
+  context 'with a nameIdentifier' do
+    subject(:record) do
+      mods_record(<<-XML)
+        <name>
+          <name type="personal">Whoopie Goldberg</name>
+          <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0002-0666-0666</nameIdentifier>
+          <role><roleTerm type='text'>some role</roleTerm></role>
+        </name>
+      XML
+    end
+
+    it 'has the expected attributes for nameIdentifier' do
+      expect(record.plain_name.nameIdentifier.first).to have_attributes(
+        text: '0000-0002-0666-0666',
+        typeURI: 'https://orcid.org',
+        type_at: 'orcid'
+      )
+    end
+  end
+
   context 'without a family name and given name' do
     subject(:record) do
       mods_record("<name type='personal'>
@@ -349,6 +370,7 @@ RSpec.describe "Mods <name> Element" do
         </name>
         <name>
             <namePart>Daniel Craig</namePart>
+            <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0002-0666-0666</nameIdentifier>
             <role>
               <roleTerm type='text' authority='marcrelator'>Actor</roleTerm>
               <roleTerm type='code' authority='marcrelator'>cre</roleTerm>
@@ -363,6 +385,12 @@ RSpec.describe "Mods <name> Element" do
         have_attributes(role: have_attributes(value: ['CreatorFake', 'Actor'], code: ['cre'], authority: ['marcrelator', 'marcrelator'], size: 2)),
         have_attributes(role: have_attributes(value: ['Actor'], code: ['cre'], authority: ['marcrelator'], size: 1)),
       ])
+      expect(record.plain_name.last.nameIdentifier.first).to have_attributes(
+        text: '0000-0002-0666-0666',
+        typeURI: 'https://orcid.org',
+        type_at: 'orcid'
+      )
+      expect(record.plain_name.first.nameIdentifier).to be_empty
     end
   end
 end


### PR DESCRIPTION
So it turns out that SDR puts Orcid info into the nameIdentifier element, which is a child of the name element.  And so to be able to display orcid info in Purl, we need stanford-mods methods to be able to access nameIdentifier, which means adding it here.

As an aside, the mods gem says it's at mods 3.4 and MODS is at 3.8 or 3.9 now ...

Part of sul-dlss/purl#717