### PR TITLE
languages: accommodate codes without authorities

### DIFF
--- a/lib/mods/record.rb
+++ b/lib/mods/record.rb
@@ -168,13 +168,13 @@ module Mods
       @mods_ng_xml.language.each { |n|
         # get languageTerm codes and add their translations to the result
         n.code_term.each { |ct|
-          if ct.authority.match(/^iso639/)
+          if !ct.authority.empty? && ct.authority.match(/^iso639/)
             begin
               vals = ct.text.split(/[,|\ ]/).reject {|x| x.strip.length == 0 }
               vals.each do |v|
                 result << ISO_639.find(v.strip).english_name
               end
-            rescue => e
+            rescue StandardError
               p "Couldn't find english name for #{ct.text}"
               result << ct.text
             end

--- a/spec/lib/language_spec.rb
+++ b/spec/lib/language_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Mods <language> Element' do
     end
   end
 
-  context 'wih a record with some authority attributes' do
+  context 'with a record with some authority attributes' do
     subject(:record) do
       mods_record(<<-XML)
         <language><languageTerm authorityURI='http://example.com' valueURI='http://example.com/zzz'>zzz</languageTerm></language>
@@ -117,6 +117,23 @@ RSpec.describe 'Mods <language> Element' do
         it 'recognizes other authority attributes' do
           expect(record.language.languageTerm).to have_attributes(authorityURI: ['http://example.com'], valueURI: ['http://example.com/zzz'])
         end
+      end
+    end
+  end
+
+  context 'when language code without authority' do
+    subject(:record) do
+      mods_record(<<-XML)
+        <language>
+          <languageTerm type="code">eng</languageTerm>
+          <languageTerm type="text">English</languageTerm>
+        </language>
+      XML
+    end
+
+    describe '#languages' do
+      it 'contains code and text value' do
+        expect(record.languages).to eq ['eng', 'English']
       end
     end
   end


### PR DESCRIPTION
https://app.honeybadger.io/projects/50568/faults/103801039 shows 1,343 errors being thrown over the last 4 days for, e.g.

(from https://purl.stanford.edu/wy385mk2999.mods)

```xml
<language>
    <languageTerm type="code">eng</languageTerm>
    <languageTerm type="text">English</languageTerm>
</language>
```

The problem is the `languageTerm` of type `code` is supposed to have an authority.   Heavens - we have bad data!  Who knew?

This fix allows processing to continue.

Note that the `p` statement is presumably going out into space in the existing code, so no attempt to report the missing authority attribute is made in this fix.